### PR TITLE
週間メニューページの作成・ルートの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ Homestead.yaml
 Thumbs.db
 
 repomix-output.xml
+
+/testpack/

--- a/resources/views/components/back-to-dashboard-button.blade.php
+++ b/resources/views/components/back-to-dashboard-button.blade.php
@@ -1,0 +1,4 @@
+<a href="{{ route('dashboard') }}" {{ $attributes->merge(['class' => 'flex items-center gap-2 px-2 py-1 border border-smartfit-text-emphasis rounded-md text-base text-smartfit-text-emphasis tracking-[1.5px] hover:bg-smartfit-border']) }}>
+    <img src="{{ asset('images/161_10884.svg') }}" alt="Back arrow" class="transform -rotate-90">
+    <span>ダッシュボードに戻る</span>
+</a>

--- a/resources/views/components/breadcrumb.blade.php
+++ b/resources/views/components/breadcrumb.blade.php
@@ -1,0 +1,5 @@
+{{-- パンくずリストのテキストを$slotで受け取る --}}
+<div {{ $attributes->merge(['class' => 'flex items-center gap-1 text-xs font-medium text-white']) }}>
+    <img src="{{ asset('images/111_4496.svg') }}" alt="Breadcrumb Icon">
+    <span>| {{ $slot }}</span>
+</div>

--- a/resources/views/components/exercise-list.blade.php
+++ b/resources/views/components/exercise-list.blade.php
@@ -1,0 +1,3 @@
+<div class="flex flex-col gap-4">
+    {{ $slot }}
+</div>

--- a/resources/views/components/page-header.blade.php
+++ b/resources/views/components/page-header.blade.php
@@ -1,0 +1,11 @@
+<header {{ $attributes->merge(['class' => 'flex flex-col items-start gap-4']) }}>
+    {{-- パンくずリストコンポーネントを内部で使用 --}}
+    <x-breadcrumb>
+        {{-- 呼び出し元から渡されたテキストをここに表示 --}}
+        {{ $slot }}
+    </x-breadcrumb>
+
+    {{-- 「ダッシュボードに戻る」ボタンコンポーネントを内部で使用 --}}
+    <x-back-to-dashboard-button />
+
+</header>

--- a/resources/views/components/page-title.blade.php
+++ b/resources/views/components/page-title.blade.php
@@ -1,0 +1,16 @@
+@props([
+'heading', // 必須
+'sub' => null, // 任意
+])
+
+<div class="mb-6">
+    <h1 class="text-3xl font-normal text-smartfit-text-primary tracking-[1.5px] mb-2">
+        {{ $heading }}
+    </h1>
+
+    @if ($sub)
+    <p class="text-xl text-smartfit-text-secondary tracking-[1.5px]">
+        {{ $sub }}
+    </p>
+    @endif
+</div>

--- a/resources/views/components/schedule-card-header.blade.php
+++ b/resources/views/components/schedule-card-header.blade.php
@@ -1,0 +1,21 @@
+@props([
+'icon',
+'day',
+'isToday' => false // デフォルトはfalse（「今日」タグ非表示）
+])
+
+<div class="flex justify-between items-center mb-6">
+    <div class="flex items-center gap-2">
+        <img src="{{ $icon }}" alt="Calendar icon">
+        <h2 class="text-xl font-normal text-smartfit-text-primary tracking-[1.5px]">{{ $day }}</h2>
+
+        {{-- isTodayプロパティがtrueの場合のみ「今日」タグを表示 --}}
+        @if ($isToday)
+        <x-tag color="today">今日</x-tag>
+        @endif
+    </div>
+    <div class="flex items-center gap-2">
+        <x-tag>AIトレーナー</x-tag>
+        <x-tag color="action">編集</x-tag>
+    </div>
+</div>

--- a/resources/views/components/tag.blade.php
+++ b/resources/views/components/tag.blade.php
@@ -1,0 +1,15 @@
+@props(['color' => 'default'])
+
+@php
+$classes = 'inline-flex justify-center items-center px-1.5 py-0.5 rounded-sm text-xs font-medium text-smartfit-text-primary';
+
+$classes .= match ($color) {
+'action' => ' bg-smartfit-action',
+'today' => ' bg-smartfit-action',
+default => ' border border-smartfit-text-primary',
+};
+@endphp
+
+<span {{ $attributes->merge(['class' => $classes]) }}>
+    {{ $slot }}
+</span>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -22,7 +22,7 @@
                         </x-sf-nav-link>
                     </li>
                     {{-- 他のリンクも同様に追加 --}}
-                    <li><x-sf-nav-link href="#" :icon="asset('images/I123_11372_104_3586_67_3627_35_197_69_2466.svg')">{{ __('週間メニュー') }}</x-sf-nav-link></li>
+                    <li><x-sf-nav-link :href="route('weekly-menu')" :active="request()->routeIs('weekly-menu')" :icon="asset('images/I123_11372_104_3586_67_3627_35_197_69_2466.svg')">{{ __('週間メニュー') }}</x-sf-nav-link></li>
                     <li><x-sf-nav-link href="#" :icon="asset('images/I123_11372_104_3593_67_3627_35_197.svg')">{{ __('トレーニング記録') }}</x-sf-nav-link></li>
                     <li><x-sf-nav-link href="#" :icon="asset('images/I123_11372_104_3600_67_3627_35_197_30_498.svg')">{{ __('AIトレーナー') }}</x-sf-nav-link></li>
                 </ul>

--- a/resources/views/weekly-menu.blade.php
+++ b/resources/views/weekly-menu.blade.php
@@ -1,0 +1,67 @@
+<x-app-layout>
+    {{-- メインコンテンツ --}}
+    <div class="flex flex-col gap-10">
+        <!-- ページヘッダー -->
+        <x-page-header>
+            ダッシュボード / 週間メニュー
+        </x-page-header>
+
+        <!-- コンテンツタイトル -->
+        <x-page-title heading="週間メニュー" sub="AIトレーナーが提案した今週のトレーニングメニュー" />
+
+        <!-- スケジュールグリッド -->
+        <div class="grid grid-cols-1 xl:grid-cols-2 gap-7">
+
+            {{-- 月曜日のスケジュールカード --}}
+            <x-card>
+                {{-- 曜日ヘッダーコンポーネント --}}
+                <x-schedule-card-header
+                    day="月曜日"
+                    :icon="asset('images/I225_12728_67_3627.svg')" />
+
+                {{-- 運動リストコンポーネント（中身はハードコーディング） --}}
+                <x-exercise-list>
+                    <div class="bg-smartfit-tertiary-bg border border-smartfit-border rounded-lg p-4">
+                        <div class="flex items-center gap-2 mb-2">
+                            <h3 class="text-base font-normal text-smartfit-text-primary tracking-[1.5px]">ベンチプレス</h3>
+                            <span class="bg-smartfit-muscle-tag-bg border border-smartfit-text-primary rounded-sm px-1 text-xs leading-tight h-[18px]">胸</span>
+                        </div>
+                        <p class="text-xs font-medium text-smartfit-text-emphasis">3セット 8-10回 × 60kg</p>
+                    </div>
+                    <div class="bg-smartfit-tertiary-bg border border-smartfit-border rounded-lg p-4">
+                        <div class="flex items-center gap-2 mb-2">
+                            <h3 class="text-base font-normal text-smartfit-text-primary tracking-[1.5px]">インクラインプレス</h3>
+                            <span class="bg-smartfit-muscle-tag-bg border border-smartfit-text-primary rounded-sm px-1 text-xs leading-tight h-[18px]">胸</span>
+                        </div>
+                        <p class="text-xs font-medium text-smartfit-text-emphasis">3セット 10-12回 × 50kg</p>
+                    </div>
+                    {{-- ... 他の種目も同様に追加 ... --}}
+                </x-exercise-list>
+            </x-card>
+
+            {{-- 火曜日のスケジュールカード (今日) --}}
+            <x-card class="bg-smartfit-today-bg border-smartfit-action">
+                {{-- 曜日ヘッダーコンポーネント (is-todayをtrueで渡す) --}}
+                <x-schedule-card-header
+                    day="火曜日"
+                    :icon="asset('images/I225_12805_67_3627.svg')"
+                    :is-today="true" />
+
+                {{-- 運動リストコンポーネント（中身はハードコーディング） --}}
+                <x-exercise-list>
+                    <div class="bg-smartfit-tertiary-bg border border-smartfit-border rounded-lg p-4">
+                        <div class="flex items-center gap-2 mb-2">
+                            <h3 class="text-base font-normal text-smartfit-text-primary tracking-[1.5px]">スクワット</h3>
+                            <span class="bg-smartfit-muscle-tag-bg border border-smartfit-text-primary rounded-sm px-1 text-xs leading-tight h-[18px]">脚</span>
+                        </div>
+                        <p class="text-xs font-medium text-smartfit-text-emphasis">4セット 8-10回 × 60kg</p>
+                    </div>
+                    {{-- ... 他の種目も同様に追加 ... --}}
+                </x-exercise-list>
+            </x-card>
+
+            {{-- ... 以下、水曜日から日曜日のカードを同様に作成 ... --}}
+
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,13 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    /**
+     * weekly-menu(週間メニュー表示)
+     */
+    Route::get('/weekly-menu', function () {
+        return view('weekly-menu');
+    })->name('weekly-menu');
 });
 
-require __DIR__.'/auth.php';
+require __DIR__ . '/auth.php';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,7 +29,9 @@ export default {
                     'tertiary-bg': 'rgba(73, 80, 87, 0.3)', // カード背景用
                     'border-light': '#343a40',             // サイドバーの区切り線用
                     'text-emphasis': '#dee2e6',            // 強調テキスト用 (例: 筋トレ詳細)
-                    'black': '#000000'
+                    'black': '#000000',
+                    'today-bg': 'rgba(208, 34, 36, 0.1)', // is-todayのカード背景
+                    'muscle-tag-bg': 'rgba(52, 58, 64, 0.3)', // 部位タグの背景
                 }
             }
         },


### PR DESCRIPTION
週間ページの作成
- サイト全体のレイアウト構成
    - resources/views/weekly-menu.blade.php

- ヘッダーコンポーネント（パンくずとダッシュボード戻るボタン）
    - resources/views/components/page-header.blade.php

    - パンくず機能を表示するためのコンポーネント
        - resources/views/components/breadcrumb.blade.php

    - ダッシュボードの戻るボタンコンポーネント
    - resources/views/components/back-to-dashboard-button.blade.php

- ページタイトルコンポーネント
    - resources/views/components/page-title.blade.php

- スケジュールカードヘッダーコンポーネント
    - resources/views/components/schedule-card-header.blade.php

- タグコンポーネント
    - resources/views/components/tag.blade.php

- エクササイズリストコンポーネント
    - resources/views/components/exercise-list.blade.php

ルートの追加
- 週間メニュー表示のルートを追加
    - routes/web.php
- ナビゲーションメニューに週間メニューへのリンクを追加
    - resources/views/layouts/navigation.blade.php